### PR TITLE
Fix: Enable DEBUG logging for gateway routing diagnostics

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -62,4 +62,5 @@ management:
 
 logging:
   level:
-    org.springframework.cloud.gateway: INFO
+    org.springframework.cloud.gateway: DEBUG
+    org.springframework.cloud.gateway.route.RouteDefinitionRouteLocator: DEBUG


### PR DESCRIPTION
## Summary\n- Enable DEBUG level logging for Spring Cloud Gateway\n- Add route definition route locator logging for predicate matching\n- Helps diagnose 404 responses on /api/v1/contact endpoint\n\n## Changes\n- Updated `application.yml` logging configuration\n- Changed gateway logging from INFO to DEBUG\n- Added RouteDefinitionRouteLocator debug logging\n\n## Testing\n- Verified gateway starts successfully with new logging config\n- Route matching logs now visible in service output